### PR TITLE
Fix app crashing on missing url

### DIFF
--- a/src/modules/HomeView/sagas/events.js
+++ b/src/modules/HomeView/sagas/events.js
@@ -20,6 +20,9 @@ const LOCALE = 'fi';
 
 const fetchHero = function*() {
   try {
+    if (heroLink === undefined) {
+      throw new Error('Missing link URL in hero.')
+    }
     const { heroLink, myHelsinkiEventData } = yield call(fetchHeroLink)
     const linkedEventsEventData = yield call(makeRequest, heroLink + "?include=location", 'GET', null)
     yield put(EventActions.getHeroSuccess(parseHeroData(linkedEventsEventData, myHelsinkiEventData)))


### PR DESCRIPTION
Sometimes the hero event data is missing a URL. This causes the app to crash with

04-30 11:42:05.140  5137  5163 E AndroidRuntime: java.lang.IllegalArgumentException: unexpected url: undefined?include=location
04-30 11:42:05.140  5137  5163 E AndroidRuntime: 	at okhttp3.Request$Builder.url(Request.java:142)
04-30 11:42:05.140  5137  5163 E AndroidRuntime: 	at com.facebook.react.modules.network.NetworkingModule.sendRequest(NetworkingModule.java:171)
04-30 11:42:05.140  5137  5163 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
04-30 11:42:05.140  5137  5163 E AndroidRuntime: 	at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:374)
04-30 11:42:05.140  5137  5163 E AndroidRuntime: 	at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:162)
04-30 11:42:05.140  5137  5163 E AndroidRuntime: 	at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
04-30 11:42:05.140  5137  5163 E AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:789)
04-30 11:42:05.140  5137  5163 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:98)
04-30 11:42:05.140  5137  5163 E AndroidRuntime: 	at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:31)
04-30 11:42:05.140  5137  5163 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:251)
04-30 11:42:05.140  5137  5163 E AndroidRuntime: 	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run(MessageQueueThreadImpl.java:194)
04-30 11:42:05.140  5137  5163 E AndroidRuntime: 	at java.lang.Thread.run(Thread.java:764)


The problems needs to be worked around, but in the meantime, the crashing should be prevented.